### PR TITLE
Implement a loading screen with some text

### DIFF
--- a/app/components/SignupForm.tsx
+++ b/app/components/SignupForm.tsx
@@ -3,8 +3,6 @@ import { useState, ChangeEvent, FormEvent } from "react";
 import Image from "next/image";
 import {  EyeIcon, EyeOff} from "lucide-react";
 
-import Loader from "./loader";
-
 const appleLogo = "/apple-logo.svg";
 const googleLogo = "/google.svg";
 
@@ -23,7 +21,6 @@ export default function SignupForm() {
     password: "",
     agreement: false,
   });
-  const [loading, setLoading] = useState(false);
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { name, value, type, checked } = event.target;
@@ -34,14 +31,8 @@ export default function SignupForm() {
   };
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    setLoading(true);
     event.preventDefault();
     console.log(formValues);
-    setTimeout(() => {
-      console.log("Form submitted", formValues);
-      setLoading(false);
-      window.location.href = '/verify-email';
-    }, 8000);
   };
 
   const togglePassword = () => {
@@ -49,18 +40,6 @@ export default function SignupForm() {
   }
 
   return (
-    <>
-    {loading && (
-      <Loader
-        steps={[
-          "Registering your account",
-          "Generating your wallet",
-          "Securing your credentials",
-          "Account registered",
-        ]}
-        onComplete={() => setLoading(false)}
-      />
-    )}
     <form
       onSubmit={handleSubmit}
       className="font-montserrat w-full h-full max-w-[340px]  flex items-center justify-center flex-col gap-5"
@@ -162,6 +141,5 @@ export default function SignupForm() {
         </Link>
       </p>
     </form>
-    </>
   );
 }

--- a/app/components/SignupForm.tsx
+++ b/app/components/SignupForm.tsx
@@ -3,6 +3,8 @@ import { useState, ChangeEvent, FormEvent } from "react";
 import Image from "next/image";
 import {  EyeIcon, EyeOff} from "lucide-react";
 
+import Loader from "./loader";
+
 const appleLogo = "/apple-logo.svg";
 const googleLogo = "/google.svg";
 
@@ -21,6 +23,7 @@ export default function SignupForm() {
     password: "",
     agreement: false,
   });
+  const [loading, setLoading] = useState(false);
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { name, value, type, checked } = event.target;
@@ -31,8 +34,14 @@ export default function SignupForm() {
   };
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    setLoading(true);
     event.preventDefault();
     console.log(formValues);
+    setTimeout(() => {
+      console.log("Form submitted", formValues);
+      setLoading(false);
+      window.location.href = '/verify-email';
+    }, 8000);
   };
 
   const togglePassword = () => {
@@ -40,6 +49,18 @@ export default function SignupForm() {
   }
 
   return (
+    <>
+    {loading && (
+      <Loader
+        steps={[
+          "Registering your account",
+          "Generating your wallet",
+          "Securing your credentials",
+          "Account registered",
+        ]}
+        onComplete={() => setLoading(false)}
+      />
+    )}
     <form
       onSubmit={handleSubmit}
       className="font-montserrat w-full h-full max-w-[340px]  flex items-center justify-center flex-col gap-5"
@@ -141,5 +162,6 @@ export default function SignupForm() {
         </Link>
       </p>
     </form>
+    </>
   );
 }

--- a/app/components/loader.tsx
+++ b/app/components/loader.tsx
@@ -11,10 +11,10 @@ const Loader: React.FC<LoaderProps> = ({ steps = [], onComplete }) => {
   useEffect(() => {
     if (steps.length === 0) return;
     if (currentStep < steps.length - 1) {
-      const timer = setTimeout(() => setCurrentStep(currentStep + 1), 2000);
+      const timer = setTimeout(() => setCurrentStep(currentStep + 1), 700);
       return () => clearTimeout(timer);
     } else {
-      const completeTimer = setTimeout(() => onComplete && onComplete(), 2000);
+      const completeTimer = setTimeout(() => onComplete && onComplete(), 1500);
       return () => clearTimeout(completeTimer);
     }
   }, [currentStep, steps.length, onComplete]);

--- a/app/components/loader.tsx
+++ b/app/components/loader.tsx
@@ -1,0 +1,39 @@
+import { useState, useEffect } from "react";
+
+interface LoaderProps {
+  steps?: string[];
+  onComplete?: () => void;
+}
+
+const Loader: React.FC<LoaderProps> = ({ steps = [], onComplete }) => {
+  const [currentStep, setCurrentStep] = useState(0);
+
+  useEffect(() => {
+    if (steps.length === 0) return;
+    if (currentStep < steps.length - 1) {
+      const timer = setTimeout(() => setCurrentStep(currentStep + 1), 2000);
+      return () => clearTimeout(timer);
+    } else {
+      const completeTimer = setTimeout(() => onComplete && onComplete(), 2000);
+      return () => clearTimeout(completeTimer);
+    }
+  }, [currentStep, steps.length, onComplete]);
+
+  if (steps.length === 0) return null;
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className="bg-white p-6 rounded-lg shadow-lg text-center w-80">
+        <p className="text-lg font-semibold mb-4">{steps[currentStep]}</p>
+        <div className="w-full bg-gray-200 h-2 rounded-full overflow-hidden">
+          <div
+            className="bg-blue-500 h-full transition-all duration-200"
+            style={{ width: `${((currentStep + 1) / steps.length) * 100}%` }}
+          ></div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Loader;

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -1,10 +1,36 @@
 'use client'
-import React from 'react'
+import React, { useState } from 'react'
 import { signIn, signOut, useSession } from "next-auth/react";
-
+import Loader from '../components/loader';
 export default function Navbar() {
   const { data: session } = useSession();
+
+  const [loading, setLoading] = useState(false);
+
+  
+  const handleRegister = async () => {
+    setLoading(true);
+    try {
+      await signIn("google");
+      setLoading(false);
+    } catch (error) {
+      console.error("Sign-in failed:", error);
+      setLoading(false);
+    }
+  };
   return (
+    <>
+    {loading && (
+      <Loader
+        steps={[
+          "Registering your account",
+          "Generating your wallet",
+          "Securing your credentials",
+          "Account registered",
+        ]}
+        onComplete={() => setLoading(false)}
+      />
+    )}
     <nav className='font-[family-name:var(--font-monstserrat)] w-full h-24 flex items-center justify-between bg-white'>
         <p className='text-black font-bold text-[2.125rem]'>Nebula</p>
 
@@ -13,10 +39,11 @@ export default function Navbar() {
         {session ? (
           <button className='px-6 py-2 rounded-full flex justify-center items-center bg-[#3D46FF] font-normal text-[18px] text-white' onClick={() => signOut()}>{session.user?.name}</button>
       ) : (
-        <button className='px-12 py-2 rounded-full flex justify-center items-center bg-[#3D46FF] font-normal text-[18px] text-white' onClick={() => signIn("google")}>Register</button>
+        <button className='px-12 py-2 rounded-full flex justify-center items-center bg-[#3D46FF] font-normal text-[18px] text-white' onClick={handleRegister}  disabled={loading}>{loading ? "Processing..." : "Register"}</button>
        
       )}
         </div>
     </nav>
+    </>
   )
 }


### PR DESCRIPTION
closes #36 
https://github.com/user-attachments/assets/0a6840f9-a988-42f5-87cf-c9b6ed7f8557

created a loader in /components 


how to use 
the loader is a reusable component so you can call it this way 
{loading && (
      <Loader
        steps={[
          "Registering your account",
          "Generating your wallet",
          "Securing your credentials",
          "Account registered",
        ]}
        onComplete={() => setLoading(false)}
      />
    )}
    
    i created a handlesubmit in the navbar to test it so when the user clicks on it 
     const handleRegister = async () => {
    setLoading(true);
    try {
      await signIn("google");
      setLoading(false);
    } catch (error) {
      console.error("Sign-in failed:", error);
      setLoading(false);
    }
  };